### PR TITLE
fix: overflow issue_title and error handling of async process

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -84,7 +84,7 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
   console.log("sending ");
   if (process.env.ENABLE_FORUM === "true" ){
     console.log(' post ...');
-    axios.post(
+    await axios.post(
       `${payload_url}?wait=true`,
       postPayload,
       {

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -60,7 +60,7 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
 
   //trimming the issue title to 100 characters as more than that is not allowed
   if (issue_title.length > 100) {
-    issue_title = issue_title.slice(0, 100)
+    issue_title = `${issue_title.slice(0, 97)}...`
   }
 
   url = process.env.DISCORD_WEBHOOK;

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -58,6 +58,11 @@ if (argv._.length === 0 && !process.env.DISCORD_EMBEDS) {
      }
   }
 
+  //trimming the issue title to 100 characters as more than that is not allowed
+  if (issue_title.length > 100) {
+    issue_title = issue_title.slice(0, 100)
+  }
+
   url = process.env.DISCORD_WEBHOOK;
   payload_url = process.env.DISCORD_WEBHOOK_FORUM;
   payload = JSON.stringify({


### PR DESCRIPTION
- Primary issue was when issue_tittle was overflowing to 100 characters it was Discord doesn't allowed to create a post
- Firstly, in the async process the function to post wasn't awaited so therefore it was a floating promise as a result the error message was never clear Fixed that
- Implemented a small logic to handle overflowing characters